### PR TITLE
1차 TanStack-Query-Challenge 제출

### DIFF
--- a/challengers/leejs0823/useMutation.js
+++ b/challengers/leejs0823/useMutation.js
@@ -1,0 +1,20 @@
+const QueryCache = require("../../query-cache.js");
+const queryCache = new QueryCache();
+
+function useMutation({ mutationFn, onSuccess, onError }) {
+  async function mutate(variables) {
+    try {
+      const data = await mutationFn(variables);
+      if (onSuccess) {
+        onSuccess(data);
+      }
+    } catch (err) {
+      if (onError) {
+        onError(err);
+      }
+    }
+  }
+  return { mutate };
+}
+
+module.exports = useMutation;

--- a/challengers/leejs0823/useQuery.js
+++ b/challengers/leejs0823/useQuery.js
@@ -1,0 +1,30 @@
+const QueryCache = require("../../query-cache.js");
+const queryCache = new QueryCache();
+
+function useQuery({ queryKey, queryFn, cacheTime }) {
+  let isLoading = true;
+  let error = null;
+  let data = null;
+  async function fetchData() {
+    try {
+      const cachedQuery = queryCache.getQuery(queryKey);
+      if (!cachedQuery || Date.now() - cachedQuery.timestamp > cacheTime) {
+        // 해당 queryKey로 저장된 캐시가 없거나 저장된 데이터의 cacheTime이 만료되었을 경우 새로운 데이터를 가져온다
+        const response = await queryFn();
+        data = response;
+        queryCache.addQuery(queryKey, { data, timestamp: Date.now() });
+      } else {
+        data = cachedQuery.data;
+      }
+    } catch (err) {
+      error = err;
+      isLoading = false;
+      return { error, isLoading };
+    }
+    isLoading = false;
+    return { data, isLoading, error };
+  }
+  fetchData();
+}
+
+module.exports = useQuery;

--- a/query-cache.js
+++ b/query-cache.js
@@ -21,3 +21,5 @@ class QueryCache {
     });
   }
 }
+
+module.exports = QueryCache;


### PR DESCRIPTION
## 🖥️ 챌린지 작업 내용 설명

<!-- 이것은 보이지 않는 주석입니다 ```javascript 엔터 ``` 를통해 코드를 이쁘게 적어둘 수 있어요! 노션에서 쓰듯이 이쁘게 설명해주세요! -->

## 🔍 챌린지 진행 도중에 코드를 짜는 데에 있어서 어려웠던 점

useQuery, useMutation가 동작하는 과정을 직접 구현하는 게 쉽지 않았다. 자바스크립트 코드를 직접 짜는것도 너무 오랜만이라 어려웠다... 앞으로도 처음부터 끝까지 고민하며 직접 코드를 짜는 습관을 길러야겠다고 생각했다!
<!-- 어떤 점이 가장 코드 짜는 데에 있어서 어려웠나요?  -->

## 🤔 챌린지 진행 도중에 생긴 궁금증

일단 `invalidateQueries` 이 캐시 무효화 로직을 활용하지 못했다. useMutation의 작동방식을 찾아봤을 때 나온 내용이 delete, update 등을 수행할 때 캐시값이 바뀌게 되면 기존 캐쉬를 무효화하고 새로운 값을 받아와서 저장해야하는데 이때 캐시 무효화가 필요하다고 한다. 그런데 보통은 onSuccess 에서 직접 캐시 무효화 코드를 작성한다고 해서 실제 useMutation 처럼 작동하게 하려면 invalidateQueries를 어디에 추가해야할지 몰라서 일단 제외해두었다 .. 
<!-- TanStack-Query의 작동 방식에 대해서 조금 더 알고싶나요? 뭐가 궁금한가요? -->

## 📝 느낀점

그래도 이렇게 라이브러리의 동작 과정을 공부하고 이를 직접 작성해보고자 고민하는 과정에서 라이브러리에 대한 이해도가 더 높아지는 것 같다. 한 번 해보니 앞으로도 이런 스터디 더 해보고 싶다!
<!-- 부족했던 점이나, 생성형 AI의 도움을 받지 않고 직접 코드를 작성하면서 느낀 점을 적어주세요! -->
